### PR TITLE
Fix issue with NODE object addition

### DIFF
--- a/api/autoload.php
+++ b/api/autoload.php
@@ -94,7 +94,7 @@ function generateWhere ($search, $and_or, $db, $b2b, $skip_keys = array()) {
                    if(in_array($key, $skip_keys)) continue;                   
 
                    // SKIP EMPTY VALUES
-                   if($value == NULL || $value == "" || $value == -1) continue;
+                   if($value == NULL || $value == "" || ($value+0) == -1) continue;
 
                    $eqlike = preg_match("/%/", $value) ? " like " : " = ";
 


### PR DESCRIPTION
Added boolean to integer conversation as a "+0" operation in generateWhere function.
This fixed an issue which made unavailable to add new NODE objects.
