### PR TITLE
Rotation scripts fixes

### DIFF
--- a/scripts/partrotate_unixtimestamp.pl
+++ b/scripts/partrotate_unixtimestamp.pl
@@ -25,8 +25,8 @@ use DBI;
 $version = "0.4.0";
 $mysql_table = $ARGV[1] // "sip_capture";
 $mysql_dbname = $ARGV[0] // "homer_data";
-$mysql_user = "mysql_login";
-$mysql_password = "mysql_password";
+$mysql_user = "homer_user";
+$mysql_password = "homer_password";
 $mysql_host = "localhost";
 $maxparts = $ARGV[3] // 6; #6 days How long keep the data in the DB
 $newparts = 2; #new partitions for 2 days. Anyway, start this script daily!

--- a/scripts/rotate.sh
+++ b/scripts/rotate.sh
@@ -2,8 +2,9 @@
 
 #this is script rotation for rtcp, logs and stats tables
 
-new_table="/usr/local/bin/new_table.pl"
-programm="/usr/local/bin/partrotate_unixtimestamp.pl"
+bin_dir=`dirname $0`
+new_table="$bin_dir/homer_mysql_new_table.pl"
+programm="$bin_dir/homer_mysql_partrotate_unixtimestamp.pl"
 
 #Make new table rotate. Homer5 Style.
 $new_table

--- a/scripts/rotate.sh
+++ b/scripts/rotate.sh
@@ -2,6 +2,9 @@
 
 #this is script rotation for rtcp, logs and stats tables
 
+# Set correct bin path if we are running as a cron job
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
 bin_dir=`dirname $0`
 new_table="$bin_dir/homer_mysql_new_table.pl"
 programm="$bin_dir/homer_mysql_partrotate_unixtimestamp.pl"


### PR DESCRIPTION
FIX: bin directory independence for main rotation script
FIX: homer default DB user and password for partrotate_unixtimestamp.pl script
