### PR TITLE
Use full path for index.php in .htaccess

### DIFF
--- a/api/.htaccess
+++ b/api/.htaccess
@@ -1,6 +1,6 @@
 RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^(.*)$ index.php [L]
+RewriteRule ^(.*)$ /api/index.php [L]
 
 DirectorySlash Off

--- a/api/RestApi/Admin.php
+++ b/api/RestApi/Admin.php
@@ -444,7 +444,7 @@ class Admin {
         $update['name'] = getVar('name', '', $param, 'string');        
           
         $exten = "";
-        $callwhere = generateWhere($update, 1, $db, 0, array('dbpassword'));
+        $callwhere = generateWhere($update, 1, $db, 0);
         if(count($callwhere)) {
                 $exten .= implode(", ", $callwhere);                
         }
@@ -487,9 +487,9 @@ class Admin {
         $update['dbtables'] = getVar('dbtables', '', $param, 'string');        
         $update['name'] = getVar('name', '', $param, 'string');            
         $id = getVar('id', 0, $param, 'int');            
-          
+
         $exten = "";
-        $callwhere = generateWhere($update, 1, $db, 0, array('dbpassword'));
+        $callwhere = generateWhere($update, 1, $db, 0);
         if(count($callwhere)) {
                 $exten .= implode(", ", $callwhere);                
         }


### PR DESCRIPTION
The provided .htaccess specifies `RewriteRule ^(.*)$ index.php [L]`, but the instructions indicate to place the api-files in a folder /api.

I get a 404 not found on my apache (Apache/2.4.7) stating that it could not find index.php. This change (to `RewriteRule ^(.*)$ /api/index.php [L]`) fixes that, but I'm not sure if it occurs on all systems.
