### PR TITLE
Don't skip dbpassword when creating or updating a node.

### DIFF
--- a/api/RestApi/Admin.php
+++ b/api/RestApi/Admin.php
@@ -444,7 +444,7 @@ class Admin {
         $update['name'] = getVar('name', '', $param, 'string');        
           
         $exten = "";
-        $callwhere = generateWhere($update, 1, $db, 0, array('dbpassword'));
+        $callwhere = generateWhere($update, 1, $db, 0);
         if(count($callwhere)) {
                 $exten .= implode(", ", $callwhere);                
         }
@@ -489,7 +489,7 @@ class Admin {
         $id = getVar('id', 0, $param, 'int');            
           
         $exten = "";
-        $callwhere = generateWhere($update, 1, $db, 0, array('dbpassword'));
+        $callwhere = generateWhere($update, 1, $db, 0);
         if(count($callwhere)) {
                 $exten .= implode(", ", $callwhere);                
         }


### PR DESCRIPTION
When a node is added or updated, the code lists the dbpassword field in the ignores. Therefore, it is impossible to add or update a node from the UI.
