### PR TITLE
When building call flows or show messages, use micro_ts instead of date

### DIFF
--- a/api/RestApi/Search.php
+++ b/api/RestApi/Search.php
@@ -180,7 +180,7 @@ class Search {
 			    $table = "sip_capture_".$query_type."_".gmdate("Ymd", $ts);
 			    $query  = "SELECT t.".FIELDS_CAPTURE.", '".$query_type."' as trans, '".$node['name']."' as dbnode";
 			    $query .= " FROM ".$table." as t ";
-			    $query .= " WHERE (t.date BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
+			    $query .= " WHERE (FROM_UNIXTIME(t.micro_ts DIV 1000000) BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
 			    if(count($callwhere)) $query .= " AND ( " .implode(" AND ", $callwhere). ")";
 			    $noderows = $db->loadObjectArray($query.$order);
 			    $data = array_merge($data,$noderows);
@@ -305,7 +305,7 @@ class Search {
 			$table = "sip_capture_".$query_type."_".gmdate("Ymd", $ts);
 			$query  = "SELECT t.".$fields.", '".$query_type."' as trans, '".$node['name']."' as dbnode";
 			$query .= " FROM ".$table." as t";
-			$query .= " WHERE (t.date BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
+			$query .= " WHERE (FROM_UNIXTIME(t.micro_ts DIV 1000000) BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
 			if(count($callwhere)) $query .= " AND ( " .implode(" AND ", $callwhere). ")";
 			$noderows = $db->loadObjectArray($query.$order);
 			$data = array_merge($data,$noderows);
@@ -437,7 +437,7 @@ class Search {
 		    $table = "sip_capture_".$query_type."_".gmdate("Ymd", $ts);
 		    $query  = "SELECT t.*, '".$query_type."' as trans ";
 		    $query .= "FROM ".$table." as t";
-		    $query .= " WHERE (t.date BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
+		    $query .= " WHERE (FROM_UNIXTIME(t.micro_ts DIV 1000000) BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
 		    if(count($callwhere)) $query .= " AND ( " .implode(" AND ", $callwhere). ")";
 		    $noderows = $db->loadObjectArray($query.$order);
 		    $data = array_merge($data,$noderows);
@@ -509,7 +509,7 @@ class Search {
 		    $table = "sip_capture_".$query_type."_".gmdate("Ymd", $ts);
 		    $query  = "SELECT t.*, '".$query_type."' as trans";
 		    $query .= " FROM ".$table." as t";
-		    $query .= " WHERE (t.date BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
+		    $query .= " WHERE (FROM_UNIXTIME(t.micro_ts DIV 1000000) BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
 		    if(count($callwhere)) $query .= " AND ( " .implode(" AND ", $callwhere). ")";
 		    $noderows = $db->loadObjectArray($query.$order);
 		    $data = array_merge($data,$noderows);
@@ -616,7 +616,7 @@ class Search {
 			$table = "sip_capture_".$query_type."_".gmdate("Ymd", $ts);
 			$query  = "SELECT t.*, '".$query_type."' as trans,'".$node['name']."' as dbnode";
 			$query .= " FROM ".$table." as t";
-			$query .= " WHERE (t.date BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
+			$query .= " WHERE (FROM_UNIXTIME(t.micro_ts DIV 1000000) BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
 			if(count($callwhere)) $query .= " AND ( " .implode(" AND ", $callwhere). ")";
 			$noderows = $db->loadObjectArray($query.$order);
 			$data = array_merge($data,$noderows);


### PR DESCRIPTION
I know this is a rather un-sophisticated and debatable pull request, but I've found this change useful in particular when dealing with traces provided by hosts with slightly different date settings than homer.

The thing is that after the Search results are shown, the reference is micro_ts, while clicking on a message to generate the first call flow, or on a message to show a message detail, refers to 'date' instead of 'micro_ts'.

The result for me was empty message details when clicking on a message from a call flow.

e.g.: The query from the API when clicking on a message was:

```
SELECT t.*, 'call' as trans FROM sip_capture_call_20151009 as t WHERE (t.date BETWEEN FROM_UNIXTIME(1444389297) AND FROM_UNIXTIME(1444389297)) AND ( t.id = '41') LIMIT 1
```

but the data in the DB:

```
MariaDB [homer_data]> SELECT UNIX_TIMESTAMP(date), micro_ts FROM sip_capture_call_20151009 WHERE id='41';
+----------------------+------------------+
| UNIX_TIMESTAMP(date) | micro_ts         |
+----------------------+------------------+
|           1444389240 | 1444389297022917 |
+----------------------+------------------+
1 row in set (0.00 sec)
```

so the query returned an empty set.

I guess another possible approach could be to "open up" the time windows of the searches, as you did for the BYE issue.

Or perhaps there's another way to face this issue, at configuration level? Thanks.
