### PR TITLE
Alias include a capt id to distinguish same ip:port on different tracers

### DIFF
--- a/api/RestApi/Admin.php
+++ b/api/RestApi/Admin.php
@@ -242,7 +242,7 @@ class Admin {
         $data = array();
         
         $table = "alias";            
-        $query = "SELECT id,gid,ip,port,alias,status,created FROM ".$table." order by id DESC;";
+        $query = "SELECT id,gid,ip,port,capture_id,alias,status,created FROM ".$table." order by id DESC;";
         $query  = $db->makeQuery($query);                
         $data = $db->loadObjectArray($query);
 

--- a/api/RestApi/Search.php
+++ b/api/RestApi/Search.php
@@ -1263,16 +1263,16 @@ class Search {
         $db = $this->getContainer('db');
         $db->select_db(DB_CONFIGURATION);
         $db->dbconnect();
-        $query = "SELECT ip, port, alias FROM alias";
+        $query = "SELECT ip, port, capture_id, alias FROM alias";
         $aliases = $db->loadObjectArray($query);
         foreach($aliases as $alias) {
-            $alias_cache[$alias['ip'].':'.$alias['port']] = $alias['alias'];
+            $alias_cache[$alias['ip'].':'.$alias['port'].':'.$alias['capture_id']] = $alias['alias'];
         }
 
         // Apply alias when an alias is configured
         for($i=0; $i < count($data); $i++) {
-            $data[$i]['source_alias'] = ( isset($alias_cache[$data[$i]['source_ip'].':'.$data[$i]['source_port']]) ? $alias_cache[$data[$i]['source_ip'].':'.$data[$i]['source_port']] : $data[$i]['source_ip'] );
-            $data[$i]['destination_alias'] = ( isset($alias_cache[$data[$i]['destination_ip'].':'.$data[$i]['destination_port']]) ? $alias_cache[$data[$i]['destination_ip'].':'.$data[$i]['destination_port']] : $data[$i]['destination_ip'] );
+            $data[$i]['source_alias'] = ( isset($alias_cache[$data[$i]['source_ip'].':'.$data[$i]['source_port'].':'.$data[$i]['node']]) ? $alias_cache[$data[$i]['source_ip'].':'.$data[$i]['source_port'].':'.$data[$i]['node']] : $data[$i]['source_ip'] );
+            $data[$i]['destination_alias'] = ( isset($alias_cache[$data[$i]['destination_ip'].':'.$data[$i]['destination_port'].':'.$data[$i]['node']]) ? $alias_cache[$data[$i]['destination_ip'].':'.$data[$i]['destination_port'].':'.$data[$i]['node']] : $data[$i]['destination_ip'] );
         }
 
     }

--- a/sql/schema_configuration.sql
+++ b/sql/schema_configuration.sql
@@ -16,12 +16,13 @@ CREATE TABLE IF NOT EXISTS `alias` (
   `gid` int(5) NOT NULL DEFAULT 0,
   `ip` varchar(80) NOT NULL DEFAULT '',
   `port` int(10) NOT NULL DEFAULT '0',
+  `capture_id` varchar(100) NOT NULL DEFAULT '',
   `alias` varchar(100) NOT NULL DEFAULT '',
   `status` tinyint(1) NOT NULL DEFAULT 0,
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`),
-  UNIQUE KEY `host_2` (`ip`,`port`),
+  UNIQUE KEY `host_2` (`ip`,`port`,`capture_id`),
   KEY `host` (`ip`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;
 
@@ -29,10 +30,10 @@ CREATE TABLE IF NOT EXISTS `alias` (
 -- Dumping data for table `alias`
 --
 
-INSERT INTO `alias` (`id`, `gid`, `ip`, `port`, `alias`, `status`, `created`) VALUES
-(1, 10, '192.168.0.30', 0, 'proxy01', 1, '2014-06-12 20:36:50'),
-(2, 10, '192.168.0.4', 0, 'acme-234', 1, '2014-06-12 20:37:01'),
-(22, 10, '127.0.0.1:5060', 0, 'sip.local.net', 1, '2014-06-12 20:37:01');
+INSERT INTO `alias` (`id`, `gid`, `ip`, `port`, `capture_id`, `alias`, `status`, `created`) VALUES
+(1, 10, '192.168.0.30', 0, 'homer01', 'proxy01', 1, '2014-06-12 20:36:50'),
+(2, 10, '192.168.0.4', 0, 'homer01', 'acme-234', 1, '2014-06-12 20:37:01'),
+(22, 10, '127.0.0.1:5060', 0, 'homer01', 'sip.local.net', 1, '2014-06-12 20:37:01');
 
 -- --------------------------------------------------------
 
@@ -182,4 +183,3 @@ INSERT INTO `user_menu` (`id`, `name`, `alias`, `icon`, `weight`, `active`) VALU
 ('_1426001444630', 'SIP Search', 'search', 'fa-search', 10, 1),
 ('_1427728371642', 'Home', 'home', 'fa-home', 1, 1),
 ('_1431721484444', 'Alarms', 'alarms', 'fa-warning', 20, 1);
-


### PR DESCRIPTION
Homer was receiving traces from hosts that use in some conditions 127.0.0.1 i/f, so the combination IP address and port wasn't sufficient to uniquely identify them with aliases.
HEPv2 adds the opportunity to provide a capture ID, and the messages are then stored with a 'node' field like "homer01:13", where 'homer01' is the homer node name and '13' is the tracer's capture ID.
By adding the capture ID to the alias table and keys I was able to make the desired distinction.
If this PR will be accepted, I think I can also modify homer-ui's widget for Admin Alias to include the capture id field.
