### PR TITLE
add option DB_TABLE_ROTATE to toggle naming of homer_data tables

### DIFF
--- a/api/Database/Layer/mysql.php
+++ b/api/Database/Layer/mysql.php
@@ -26,7 +26,6 @@
  *
 */
 
-
 namespace Database\Layer;
 
 defined( '_HOMEREXEC' ) or die( 'Restricted access' );
@@ -36,8 +35,10 @@ class mysql {
         /*generate query for MYSQL and Search DATA GET */
         function querySearchData($layerHelper) 
         {
-        
-                $table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
+		$table = $layerHelper['table']['base']."_".$layerHelper['table']['type'];
+		if (DB_TABLE_ROTATE) {
+			$table .= "_".$layerHelper['table']['timestamp'];
+		}
                 $order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
                 $values = implode(",", $layerHelper['values']);
                 $time = $layerHelper['time'];                                
@@ -48,7 +49,7 @@ class mysql {
                 $query .= " WHERE (t.date BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
                 if(count($callwhere)) $query .= " AND ( " .implode(" ".$layerHelper['where']['type']." ", $callwhere). ")";
                 $query .= $order;
-                
+
                 return $query;
         }                                    
         
@@ -56,7 +57,10 @@ class mysql {
         function querySearchMessagesData($layerHelper) 
         {
         
-                $table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
+		$table = $layerHelper['table']['base']."_".$layerHelper['table']['type'];
+		if (DB_TABLE_ROTATE) {
+			$table .= "_".$layerHelper['table']['timestamp'];
+		}
                 $order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
                 $values = implode(",", $layerHelper['values']);
                 $time = $layerHelper['time'];                                

--- a/api/Database/Layer/pgsql.php
+++ b/api/Database/Layer/pgsql.php
@@ -39,7 +39,10 @@ class pgsql {
         function querySearchData($layerHelper) 
         {
         
-                $table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
+		$table = $layerHelper['table']['base']."_".$layerHelper['table']['type'];
+		if (DB_TABLE_ROTATE) {
+			$table .= "_".$layerHelper['table']['timestamp'];
+		}
                 $order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
                 $values = implode(",", $layerHelper['values']);
                 $time = $layerHelper['time'];                                
@@ -58,8 +61,11 @@ class pgsql {
         function querySearchMessagesData($layerHelper) 
         {
         
-                $table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
-                $order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
+		$table = $layerHelper['table']['base']."_".$layerHelper['table']['type'];
+		if (DB_TABLE_ROTATE) {
+			$table .= "_".$layerHelper['table']['timestamp'];
+		}
+		$order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
                 $values = implode(",", $layerHelper['values']);
                 $time = $layerHelper['time'];                                
                 $callwhere = $layerHelper['where']['param'];                                

--- a/api/Database/Layer/sqlite.php
+++ b/api/Database/Layer/sqlite.php
@@ -39,7 +39,10 @@ class sqlite {
         function querySearchData($layerHelper) 
         {
         
-                $table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
+		$table = $layerHelper['table']['base']."_".$layerHelper['table']['type'];
+		if (DB_TABLE_ROTATE) {
+			$table .= "_".$layerHelper['table']['timestamp'];
+		}
                 $order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
                 $values = implode(",", $layerHelper['values']);
                 $time = $layerHelper['time'];                                
@@ -58,7 +61,10 @@ class sqlite {
         function querySearchMessagesData($layerHelper) 
         {
         
-                $table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
+		$table = $layerHelper['table']['base']."_".$layerHelper['table']['type'];
+		if (DB_TABLE_ROTATE) {
+			$table .= "_".$layerHelper['table']['timestamp'];
+		}
                 $order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
                 $values = implode(",", $layerHelper['values']);
                 $time = $layerHelper['time'];                                

--- a/api/RestApi/Search.php
+++ b/api/RestApi/Search.php
@@ -553,7 +553,10 @@ class Search {
 		if($trans[$query_type]) {
 		    if($limit < 1) break;
 		    $order = " LIMIT ".$limit;
-		    $table = "sip_capture_".$query_type."_".gmdate("Ymd", $ts);
+		    $table = "sip_capture_".$query_type;
+		    if ( DB_TABLE_ROTATE ){
+			    $table .= "_".gmdate("Ymd", $ts);
+		    }
 		    $query  = "SELECT t.*, '".$query_type."' as trans ";
 		    $query .= "FROM ".$table." as t";
 		    $query .= " WHERE (t.date BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
@@ -625,7 +628,10 @@ class Search {
 		if($trans[$query_type]) {
 		    if($limit < 1) break;
 		    $order = " order by id DESC LIMIT ".$limit;
-		    $table = "sip_capture_".$query_type."_".gmdate("Ymd", $ts);
+		    $table = "sip_capture_".$query_type;
+		    if ( DB_TABLE_ROTATE ){
+			    $table .= "_".gmdate("Ymd", $ts);
+		    }
 		    $query  = "SELECT t.*, '".$query_type."' as trans";
 		    $query .= " FROM ".$table." as t";
 		    $query .= " WHERE (t.date BETWEEN FROM_UNIXTIME(".$time['from_ts'].") AND FROM_UNIXTIME(".$time['to_ts']."))";
@@ -733,7 +739,10 @@ class Search {
 		    if($trans[$query_type]) {
 			if($limit < 1) break;
 			$order = " order by id DESC LIMIT ".$limit;
-			$table = "sip_capture_".$query_type."_".gmdate("Ymd", $ts);
+			$table = "sip_capture_".$query_type;
+			if ( DB_TABLE_ROTATE ){
+				$table .= "_".gmdate("Ymd", $ts);
+			}
 			$query  = "SELECT t.*, '".$query_type."' as trans,'".$node['name']."' as dbnode";
 			if($uniq) $query .= ", MD5(msg) as md5sum";
 			$query .= " FROM ".$table." as t";

--- a/api/configuration_example.php
+++ b/api/configuration_example.php
@@ -14,6 +14,13 @@ define('DB_STATISTIC', "homer_statistic");
 define('DB_HOMER', "homer_data");
 define('SINGLE_NODE', 1);
 
+/* DB_TABLE_ROTATE: search in tables with date addition
+ * * true (default): e.g. sip_capture_call_20160202
+ * * false: e.g.: sip_capture_call
+ * */
+
+define('DB_TABLE_ROTATE', 1);
+
 /*********************************************************************************/
 
 /* webHomer Settings 


### PR DESCRIPTION
In case you'll let mysql or cron do the cleanup/rotate of sip_capture tables you need an option to not search in tables with date addition.
