### PR TITLE
LDAP Auth also needs to update Session to reflect local admin status

### DIFF
--- a/api/Authentication/LDAP.php
+++ b/api/Authentication/LDAP.php
@@ -123,7 +123,8 @@ class LDAP extends Authentication {
 
                             if ($value == $param['username']) {
                                 $_SESSION['userlevel'] = 1; # LDAP_ADMINLEVEL;
-                                $user['grp'] = "users,admins";
+				$user['grp'] = "users,admins";
+				$_SESSION["grp"] = "users,admins";
                             }
                         }
                         return $user;


### PR DESCRIPTION
LDAP Auth fails to promote a user defined in LDAP_ADMIN_USER to an actual admin, because it does not update the user data in $_SESSION['grp']. This leads to 401s when opening the "System Admin" panel. It works with this small fix.
