### PR TITLE
Do not use ORDER BY id in search queries

### DIFF
--- a/api/Database/Layer/mysql.php
+++ b/api/Database/Layer/mysql.php
@@ -37,8 +37,13 @@ class mysql {
         function querySearchData($layerHelper) 
         {
         
-                $table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
-                $order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
+		$table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
+		if(isset($layerHelper['order']['by'])) {
+	                $order = " ORDER BY ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];
+		}
+		else {
+	                $order = " LIMIT ".$layerHelper['order']['limit'];
+		}
                 $values = implode(",", $layerHelper['values']);
                 $time = $layerHelper['time'];                                
                 $callwhere = $layerHelper['where']['param'];                                
@@ -56,8 +61,13 @@ class mysql {
         function querySearchMessagesData($layerHelper) 
         {
         
-                $table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
-                $order = " order by ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];                
+		$table = $layerHelper['table']['base']."_".$layerHelper['table']['type']."_".$layerHelper['table']['timestamp'];                        
+		if(isset($layerHelper['order']['by'])) {
+			$order = " ORDER BY ".$layerHelper['order']['by']." ".$layerHelper['order']['type']." LIMIT ".$layerHelper['order']['limit'];
+		}
+		else {
+			$order = " LIMIT ".$layerHelper['order']['limit'];
+		}
                 $values = implode(",", $layerHelper['values']);
                 $time = $layerHelper['time'];                                
                 $callwhere = $layerHelper['where']['param'];                                

--- a/api/RestApi/Search.php
+++ b/api/RestApi/Search.php
@@ -181,8 +181,6 @@ class Search {
         $layerHelper['order'] = array();                
         $layerHelper['where'] = array();                                
         $layerHelper['table']['base'] = "sip_capture";        
-        $layerHelper['order']['by'] = "id";
-        $layerHelper['order']['type'] = "DESC";
         $layerHelper['where']['type'] = $and_or ? "OR" : "AND";                
         $layerHelper['where']['param'] = $callwhere;
                 
@@ -337,8 +335,6 @@ class Search {
         $layerHelper['order'] = array();
         $layerHelper['where'] = array();
         $layerHelper['table']['base'] = "sip_capture";
-        $layerHelper['order']['by'] = "t.id";
-        $layerHelper['order']['type'] = "DESC";
         $layerHelper['where']['type'] = $and_or ? "OR" : "AND";
         $layerHelper['where']['param'] = $callwhere;
                                                                                 


### PR DESCRIPTION
As described in [Issue 58](https://github.com/sipcapture/homer-ui/issues/58), we have provided a patch to make the ORDER BY in search queries optional. Sorting by ID confuses the mysql optimizer and provokes a filesort in some mysql versions.
