### PR TITLE
[bugfix] New rotation script: fixes paths / arguments for rotation.ini

### DIFF
--- a/scripts/new/homer_mysql_rotate.pl
+++ b/scripts/new/homer_mysql_rotate.pl
@@ -24,8 +24,15 @@ use DBI;
 use POSIX;
 
 $version = "1.0.0";
-$config = $ARGV[1] // "rotation.ini";
-@stepsvalues = (86400, 3600, 1800, 900); 
+
+# Determine path and set default rotation.ini location
+$script_location = `dirname $0`;
+$script_location =~ s/^\s+|\s+$//g;
+$default_ini = $script_location."/rotation.ini";
+
+$config = $ARGV[0] // $default_ini;
+
+@stepsvalues = (86400, 3600, 1800, 900);
 $AFTER_FIX = 1;
 
 # Optionally load override configuration. perl format


### PR DESCRIPTION
When running `scripts/new/homer_mysql_rotate.pl` it wasn't picking up the argument for the ini location, the argv array element referenced was just off, so I changed from 1 to 0.

Also, I had it figure out the dir it's working from and use that as a default, but...

Additionally, when running from cron without the argument, it was looking for `rotation.ini` locally, but it didn't have working dir context, so it would fail to load it. So I added a little logic to have it figure out what dir the script is working in and reference the absolute path. I just used bashes `dirname` for the special `$0` value in perl. I think that Perl had a `Cwd` module which will figure out the absolute path, but, my perl is a tiny bit rusty. Feel free to update that if you're more of a perl guru than I.
