### PR TITLE
Load config overrides for rotate script after loading default config,…

### DIFF
--- a/scripts/new/homer_mysql_rotate.pl
+++ b/scripts/new/homer_mysql_rotate.pl
@@ -40,15 +40,16 @@ $| =1;
 $AFTER_FIX = 1;
 $msgsize = 1400;
 
+%CONFIG = {};
+
+read_config($config);
+
 # Optionally load override configuration. perl format
 $rc = "/etc/sysconfig/partrotaterc";
 if (-e $rc) {
   do $rc;
 }
 
-%CONFIG = {};
-
-read_config($config);
 
 $newtables = $CONFIG{"MYSQL"}{"newtables"};
 $engine = $CONFIG{"MYSQL"}{"engine"};


### PR DESCRIPTION
… otherwise it does not get overriden.

I need to override the database access values for the rotation script, but I do not want to write these values in the rotation.ini included in the repo: I manage my host using puppet and do not want to have a copy of homer-api (scripts/new/rotation.ini) with modifications that puppet will override.
So I used /etc/sysconfig/partorotaterc 
I do not know exactly what was the original intention behind the partrotaterc, or what was the intended format, but I found that the only way to have the script using the overriden values is formatting partrotaterc like this:

`
$CONFIG{"MYSQL"}{"user"} = "homer_user";
$CONFIG{"MYSQL"}{"password"} = "homer_password";
$CONFIG{"MYSQL"}{"host"} = "homer_host";
`
And for this to work, config from partrotate file must be loaded after default config from rotation.ini, hence this pull request
