### PR TITLE
rotation: cronjob for partition removal, don't use partition removal per default

### DIFF
--- a/scripts/homer_partremove
+++ b/scripts/homer_partremove
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Set correct bin path if we are running as a cron job
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+bin_dir=`dirname $0`
+programm="$bin_dir/homer_mysql_remove_partitions.pl"
+config="$bin_dir/rotation.ini"
+
+$programm $config
+

--- a/scripts/rotation.ini
+++ b/scripts/rotation.ini
@@ -36,7 +36,7 @@
     # Remove partitions older than $seconds
     # Ignored if zero
     sip_capture_call = 0
-    sip_capture_registration = 21600
+    sip_capture_registration = 0
     sip_capture_rest = 0
     rtcp_capture = 0
     logs_capture = 0

--- a/scripts/sipcapture.crontab
+++ b/scripts/sipcapture.crontab
@@ -3,3 +3,4 @@
 # at low traffic time
 
 30 4 * * * root /usr/bin/homer_rotate > /dev/null 2>&1
+2 * * * *  root /usr/bin/homer_partremove > /dev/null 2>&1


### PR DESCRIPTION
Hi Alexandr,

you merged a pull request (#93) from @SipSeb today. This is a follow-up on that merge request, changing the following things:
- Don't do partition removal by default (rotation.ini now has 0 for all fields in DROP_OLD_PARTITIONS)
- Add wrapper script around homer_mysql_remove_partitions.pl like it's already done for homer_rotate. It's called homer_partremove.
- Add cronjob to sipcapture.crontab to run homer_partremove hourly (which does nothing by default, as it's not enabled in rotation.ini)
