### PR TITLE
Add destination stats

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -61,7 +61,7 @@ Server::create(WEBROOT.'api/v1', 'RestApi\Auth') //base entry points `/admin`
     ->addPostRoute('user', 'doUser') // => /api/session
     ->addDeleteRoute('session', 'doLogout') // => /admin/logout
     ->addGetRoute('logout', 'doLogout') // => /admin/logout
-    
+
     ->addSubController('search', 'RestApi\Search') //adds a new sub entry point 'tools' => admin/tools
       ->addPostRoute('data', 'doSearchData') // => /api/session
       ->addPostRoute('export/data/archive', 'doArchiveExportData') // => /api/session
@@ -71,19 +71,19 @@ Server::create(WEBROOT.'api/v1', 'RestApi\Auth') //base entry points `/admin`
       ->addPostRoute('sharelink', 'doShareLink') // => /api/session
       ->addPostRoute('share/transaction', 'doSearchShareTransaction') // => /api/session
       ->addPostRoute('share/export/pcap', 'doPcapExportById') // => /api/session
-      ->addPostRoute('share/export/text', 'doTextExportById') // => /api/session      
+      ->addPostRoute('share/export/text', 'doTextExportById') // => /api/session
       ->addPostRoute('export/pcap', 'doPcapExport') // => /api/session
       ->addPostRoute('export/text', 'doTextExport') // => /api/session
-      ->addPostRoute('export/cloud', 'doCloudExport') // => /api/session      
+      ->addPostRoute('export/cloud', 'doCloudExport') // => /api/session
       ->addPostRoute('export/data/pcap', 'doPcapExportData') // => /api/session
       ->addPostRoute('export/data/text', 'doTextExportData') // => /api/session
-      ->addPostRoute('export/data/cloud', 'doCloudExportData') // => /api/session      
-      ->addPostRoute('export/data/count', 'doCountExportData') // => /api/session    
-      ->addPostRoute('export/data/transarchive', 'doTransactionArchiveExportData') // => /api/session  
+      ->addPostRoute('export/data/cloud', 'doCloudExportData') // => /api/session
+      ->addPostRoute('export/data/count', 'doCountExportData') // => /api/session
+      ->addPostRoute('export/data/transarchive', 'doTransactionArchiveExportData') // => /api/session
       ->addGetRoute('data', 'getSearchData') // => /api/session
     ->done()
 
-    /* statistic */    
+    /* statistic */
     ->addSubController('statistic', 'RestApi\Statistic') //adds a new sub entry point 'tools' => admin/tools
       ->addGetRoute('method', 'getStatisticMethod') // => /api/session
       ->addPostRoute('method', 'doStatisticMethod') // => /api/session
@@ -99,17 +99,19 @@ Server::create(WEBROOT.'api/v1', 'RestApi\Auth') //base entry points `/admin`
       ->addGetRoute('country', 'getStatisticCountry') // => /api/session
       ->addPostRoute('useragent', 'doStatisticUserAgent') // => /api/session
       ->addGetRoute('useragent', 'getStatisticUserAgent') // => /api/session
+      ->addPostRoute('destination', 'doStatisticDestination') // => /api/session
+      ->addGetRoute('destination', 'getStatisticDestination') // => /api/session
     ->done()
 
-    /* alarm */    
+    /* alarm */
     ->addSubController('alarm', 'RestApi\Alarm') //adds a new sub entry point 'tools' => admin/tools
       ->addGetRoute('config/get', 'getAlarmConfig') // => /api/session
       ->addPostRoute('config/new', 'doNewAlarmConfig') // => /api/session
       ->addPostRoute('config/edit', 'doEditAlarmConfig') // => /api/session
-      ->addDeleteRoute('config/delete/([0-9]+)', 'deleteAlarmConfig')      
-      ->addGetRoute('list/get', 'getAlarmList') // => /api/session      
-      ->addPostRoute('list/get', 'doAlarmList') // => /api/session      
-      ->addPostRoute('list/edit', 'doEditAlarmList') // => /api/session      
+      ->addDeleteRoute('config/delete/([0-9]+)', 'deleteAlarmConfig')
+      ->addGetRoute('list/get', 'getAlarmList') // => /api/session
+      ->addPostRoute('list/get', 'doAlarmList') // => /api/session
+      ->addPostRoute('list/edit', 'doEditAlarmList') // => /api/session
       ->addGetRoute('method', 'getAlarmMethod') // => /api/session
       ->addPostRoute('method', 'doAlarmMethod') // => /api/session
       ->addPostRoute('ip', 'doAlarmIP') // => /api/session
@@ -136,53 +138,53 @@ Server::create(WEBROOT.'api/v1', 'RestApi\Auth') //base entry points `/admin`
     ->done()
 
 
-    /* admin */    
+    /* admin */
     ->addSubController('admin', 'RestApi\Admin') //adds a new sub entry point 'tools' => admin/tools
       ->addGetRoute('user/get', 'getUser') // => /api/session
       ->addGetRoute('user/get/([0-9A-Za-z_])', 'getUserById') // => /api/session
       ->addPostRoute('user/new', 'doNewUser') // => /api/session
       ->addPostRoute('user/edit', 'doEditUser') // => /api/session
-      ->addDeleteRoute('user/delete/([0-9]+)', 'deleteUser')      
+      ->addDeleteRoute('user/delete/([0-9]+)', 'deleteUser')
 
-      /* alias */          
+      /* alias */
       ->addGetRoute('alias/get', 'getAlias') // => /api/session
       ->addGetRoute('user/get/([0-9A-Za-z_])', 'getAliasById') // => /api/session
       ->addPostRoute('alias/new', 'doNewAlias') // => /api/session
       ->addPostRoute('alias/edit', 'doEditAlias') // => /api/session
-      ->addDeleteRoute('alias/delete/([0-9]+)', 'deleteAlias')          
+      ->addDeleteRoute('alias/delete/([0-9]+)', 'deleteAlias')
       /* nodes */
       ->addGetRoute('node/get', 'getNode') // => /api/session
       ->addGetRoute('node/get/([0-9A-Za-z_])', 'getNodeById') // => /api/session
       ->addPostRoute('node/new', 'doNewNode') // => /api/session
       ->addPostRoute('node/edit', 'doEditNode') // => /api/session
-      ->addDeleteRoute('node/delete/([0-9]+)', 'deleteNode')                
+      ->addDeleteRoute('node/delete/([0-9]+)', 'deleteNode')
       /* alarms */
       ->addGetRoute('useragent', 'getAlarmUserAgent') // => /api/session
     ->done()
 
-         
+
     ->addSubController('profile', 'RestApi\Profile') //adds a new sub entry point 'tools' => admin/tools
       ->addPostRoute('store/([0-9A-Za-z_-]+)', 'postIdProfile')
       ->addPostRoute('store', 'postProfile')
-      ->addGetRoute('store/([0-9A-Za-z_-]+)', 'getIdProfile')      
+      ->addGetRoute('store/([0-9A-Za-z_-]+)', 'getIdProfile')
       ->addGetRoute('store', 'getProfile')
-      ->addDeleteRoute('store/([0-9A-Z_-]+)', 'deleteIdProfile')      
+      ->addDeleteRoute('store/([0-9A-Z_-]+)', 'deleteIdProfile')
       ->addDeleteRoute('store', 'deleteProfile')
     ->done()
-    
+
     ->addSubController('dashboard', 'RestApi\Dashboard') //adds a new sub entry point 'tools' => admin/tools
       ->addPostRoute('store/([0-9A-Za-z_-]+)', 'postIdDashboard')
       ->addPostRoute('store', 'postDashboard')
       ->addPostRoute('upload', 'uploadDashboard')
-      ->addGetRoute('store/1', 'newDashboard')      
+      ->addGetRoute('store/1', 'newDashboard')
       ->addPostRoute('menu/([0-9A-Za-z_-]+)', 'postMenuDashboard')
       ->addGetRoute('node', 'getNode')
-      ->addGetRoute('store/([0-9A-Za-z_-]+)', 'getIdDashboard')      
+      ->addGetRoute('store/([0-9A-Za-z_-]+)', 'getIdDashboard')
       ->addGetRoute('store', 'getDashboard')
-      ->addDeleteRoute('store/([0-9A-Za-z_-]+)', 'deleteIdDashboard')      
+      ->addDeleteRoute('store/([0-9A-Za-z_-]+)', 'deleteIdDashboard')
       ->addDeleteRoute('store', 'deleteDashboard')
     ->done()
-    
+
 ->run();
 
 ?>

--- a/sql/schema_statistic.sql
+++ b/sql/schema_statistic.sql
@@ -173,6 +173,54 @@ CREATE TABLE IF NOT EXISTS `stats_geo` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `stats_dest_mem`
+--
+
+CREATE TABLE IF NOT EXISTS `stats_dest_mem` (
+`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT ,
+  `create_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `prefix` varchar(50) NOT NULL,
+  `method` varchar(50) NOT NULL DEFAULT '',
+  `reply_reason` varchar(100) NOT NULL DEFAULT '',
+  `country` varchar(255) NOT NULL DEFAULT 'UN',
+  `lat` float NOT NULL DEFAULT '0',
+  `lon` float NOT NULL DEFAULT '0',
+  `duration` int,
+  `total` int(20) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `datemethod` (`country` ,`prefix`,`method`)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `stats_dest_reply`
+--
+
+CREATE TABLE IF NOT EXISTS `stats_dest_reply` (
+`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `from_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `to_date` timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  `prefix` varchar(50) NOT NULL,
+  `method` varchar(50) NOT NULL DEFAULT '',
+  `reply_reason` varchar(100) NOT NULL DEFAULT '',
+  `country` varchar(255) NOT NULL DEFAULT 'UN',
+  `lat` float NOT NULL DEFAULT '0',
+  `lon` float NOT NULL DEFAULT '0',
+  `total` int(20) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`,`from_date`),
+  UNIQUE KEY `datemethod` (`from_date`,`to_date`, `country`, `prefix`,`method`),
+  KEY `from_date` (`from_date`),
+  KEY `to_date` (`to_date`),
+  KEY `prefix` (`prefix`),
+  KEY `method` (`method`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
+/*!50100 PARTITION BY RANGE ( UNIX_TIMESTAMP(`from_date`))
+(PARTITION pmax VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */ ;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `stats_method`
 --
 


### PR DESCRIPTION
This is part of a series of Pull Request affecting homer-api, homer-ui and homer-docker to provide homer the ability to generate statistics based on the destination (mainly for VoIP OUT/ interconnection with PSTN)

This P/R provides basic stats about the number of different SIP replies for each prefix and contry.
As each implementation is different, the way to provide the data to homer is to inject a header into the messages you want the statistics.
