### PR TITLE
Dashboard screen pgsql

### DIFF
--- a/api/Database/Layer/pgsql.php
+++ b/api/Database/Layer/pgsql.php
@@ -77,7 +77,7 @@ class pgsql {
                         
 			if(isset($layerHelper['fields']['replace']) && $layerHelper['fields']['replace'] == "auth")
 			{
-                                $layerHelper['values'][] = "REPLACE(REPLACE(auth, '0','N'),'1','A') AS auth";
+                                $layerHelper['values'][] = "CASE WHEN auth=0 THEN 'N' WHEN auth=1 THEN 'A' ELSE 'U' END AS auth";
                         }
                 }
 

--- a/api/RestApi/Dashboard.php
+++ b/api/RestApi/Dashboard.php
@@ -140,7 +140,7 @@ class Dashboard {
 		
 		    $boardid = str_replace(".json", "", $file);
 		    
-		    if($skipDashboards[$boardid] == 1) continue;
+		    if(array_key_exists( $boardid, $skipDashboards ) && $skipDashboards[$boardid] == 1) continue;
 		
 		    $dar = DASHBOARD_PARAM."/".$file;
 		    $myfile = fopen($dar, "r") or die("Unable to open file!");


### PR DESCRIPTION
Silence a php notice about accessing a missing array index. Rather than only rely on the index existing, this does check for exist, and value. Not sure if indexes can be in that structure with non '1' values.

For pgsql the case statement is faster than string replacement. Plus, this works in more situations as it doesn't assume the column is a text type as input, but the output is text type.
