### PR TITLE
Search - Correctly match hosts with aliases in call flows

### DIFF
--- a/api/RestApi/Search.php
+++ b/api/RestApi/Search.php
@@ -1800,8 +1800,11 @@ class Search {
                         $src_id = $data->source_ip.":".$data->source_port;
                         $dst_id = $data->destination_ip.":".$data->destination_port;
 
-		        if(!isset($hosts[$src_id])) { $hosts[$src_id] = $hostcount; $hostcount+=$host_step; }
-		        if(!isset($hosts[$dst_id])) { $hosts[$dst_id] = $hostcount; $hostcount+=$host_step; }
+                        $src_id_complete = $data->source_ip.":".$data->source_port."-".$data->node;
+                        $dst_id_complete = $data->destination_ip.":".$data->destination_port."-".$data->node;
+
+                        if(!isset($hosts[$src_id_complete])) { $hosts[$src_id_complete] = $hostcount; $hostcount+=$host_step; }
+                        if(!isset($hosts[$dst_id_complete])) { $hosts[$dst_id_complete] = $hostcount; $hostcount+=$host_step; }
 
 		        $ssrc = ":".$data->source_port;
 
@@ -1973,7 +1976,7 @@ class Search {
 		$calldata["msg_color"] = $msgcol;
 
 		/*IF */
-		if($hosts[$src_id] > $hosts[$dst_id]) $calldata["destination"] = 2;
+		if($hosts[$src_id_complete] > $hosts[$dst_id_complete]) $calldata["destination"] = 2;
 		else $calldata["destination"] = 1;
 
 		return $calldata;
@@ -2540,8 +2543,46 @@ class Search {
             // Apply source_alias
             if (isset($alias_cache[$key])) $alias = $alias_cache[$key];
             else {
+                if (preg_match('/(.*):(.*)-(.*)/', $key, $matches)) {
+                    $key_ip_address = $matches[1];
+                    $key_port = $matches[2];
+                    $key_node = $matches[3];
+
+                    if (isset($alias_cache[$key_ip_address . ":" . $key_port . "-" . $key_node])) {
+                        $alias = $alias_cache[$key_ip_address . ":" . $key_port . "-" . $key_node];
+                    }
+                    else if (isset($alias_cache[$key_ip_address . ":" . $key_port . "-*"])) {
+                        $alias = $alias_cache[$key_ip_address . ":" . $key_port . "-*"];
+                    }
+                    else if (isset($alias_cache[$key_ip_address . ":" . $key_port])) {
+                        $alias = $alias_cache[$key_ip_address . ":" . $key_port];
+                    }
+                    else if (isset($alias_cache[$key_ip_address])) {
+                        $alias = $alias_cache[$key_ip_address];
+                    }
+                    else {
+                        $alias = $key_ip_address.":".$key_port;
+                    }
+                }
+                // port was omitted in alias:
+                else if (preg_match('/(.*)-(.*)/', $key, $matches)) {
+                    $key_ip_address = $matches[1];
+                    $key_node = $matches[2];
+                    if (isset($alias_cache[$key_ip_address . "-" . $key_node])) {
+                        $alias = $alias_cache[$key_ip_address . "-" . $key_node];
+                    }
+                    else if (isset($alias_cache[$key_ip_address . "-*"])) {
+                        $alias = $alias_cache[$key_ip_address . "-*"];
+                    }
+                    else if (isset($alias_cache[$key_ip_address])) {
+                        $alias = $alias_cache[$key_ip_address];
+                    }
+                    else {
+                        $alias = $key_ip_address;
+                    }
+                }
                 // extract IP address from $key:
-                if (preg_match('/(.*):.*/', $key, $matches)) {
+                else if (preg_match('/(.*):.*/', $key, $matches)) {
                     $key_ip_address = $matches[1];
                     if (isset($alias_cache[$key_ip_address])) {
                         $alias = $alias_cache[$key_ip_address];


### PR DESCRIPTION
- Adds capture_id to hosts
- Attempts match host/alias based also on capture_id for call flows

Without this patch, even though alias matching works correctly for the messages, it doesn't work for the `hosts` inside the call flows.

e.g. an host was identified by `127.0.0.1:5060`, while the `capture_id` (`$data->node`) was in fact available. Trying to match an alias like `127.0.0.1:5060-homer01:42` would have failed. This would have impacted only the call flows, not the search results.

After the patch, hosts also contain the capture_id and matching with aliases can be made more accurately. Search results remain the same.

I haven't spotted collateral effects so far.
