### PR TITLE
Allow Unix Socket to be configured for MySQL in maintenance scripts, and use by default. Also replace split() with explode() in LDAP.php for PHP7.0 compatibility.

### DIFF
--- a/api/Authentication/LDAP.php
+++ b/api/Authentication/LDAP.php
@@ -112,13 +112,10 @@ class LDAP extends Authentication {
                         $_SESSION['username'] = $user['username'];
                         $_SESSION['gid'] = $user['gid'];
                         $_SESSION['grp'] = "users";
-                        
                         $_SESSION['data'] = $user;
-                        
-                        
 
-                        // Assigne Admin Privs, should be read from the LDAP Directory in the future
-                        $ADMIN_USER = split(",", LDAP_ADMIN_USER);
+                        // Assign Admin Privs, should be read from the LDAP Directory in the future
+                        $ADMIN_USER = explode(",", LDAP_ADMIN_USER);
                         foreach($ADMIN_USER as &$value) {
 
                             if ($value == $param['username']) {
@@ -132,7 +129,6 @@ class LDAP extends Authentication {
                 }
             }
         }
-
         return array();
     }
 
@@ -175,7 +171,6 @@ class LDAP extends Authentication {
 
         return $_SESSION['data'];
     }
-
 
     //create random password with 8 alphanumerical characters
 

--- a/scripts/homer_mysql_remove_partitions.pl
+++ b/scripts/homer_mysql_remove_partitions.pl
@@ -158,10 +158,15 @@ sub read_config {
 }
 
 sub db_connect {
-	my $CONFIG  = shift;
-	my $db_name = shift;
-
-	my $db = DBI->connect("DBI:mysql:".$CONFIG->{"MYSQL"}{$db_name}.":".$CONFIG->{"MYSQL"}{"host"}.":".$CONFIG->{"MYSQL"}{"port"}, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
-	return $db;
+    my $CONFIG  = shift;
+    my $db_name = shift;
+    my $dbi = ""
+    if($CONFIG->{"MYSQL"}{$usesocket}) {
+    	$dbi = "DBI:mysql:database=".$CONFIG->{"MYSQL"}{$db_name}.";mysql_socket=".$CONFIG->{"MYSQL"}{$socket)
+    } else {
+    	$dbi = "DBI:mysql:".$CONFIG->{"MYSQL"}{$db_name}.":".$CONFIG->{"MYSQL"}{"host"}.":".$CONFIG->{"MYSQL"}{"port"}
+    }
+    my $db = DBI->connect($dbi, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
+    return $db;
 }
 

--- a/scripts/homer_mysql_remove_partitions.pl
+++ b/scripts/homer_mysql_remove_partitions.pl
@@ -160,13 +160,13 @@ sub read_config {
 sub db_connect {
     my $CONFIG  = shift;
     my $db_name = shift;
-    my $dbi = ""
-    if($CONFIG->{"MYSQL"}{$usesocket}) {
-    	$dbi = "DBI:mysql:database=".$CONFIG->{"MYSQL"}{$db_name}.";mysql_socket=".$CONFIG->{"MYSQL"}{$socket)
+    my $dbistring = ""
+    if($CONFIG->{"MYSQL"}{"usesocket"}) {
+    	$dbi = "DBI:mysql:database=".$CONFIG->{"MYSQL"}{$db_name}.";mysql_socket=".$CONFIG->{"MYSQL"}{"socket"}
     } else {
     	$dbi = "DBI:mysql:".$CONFIG->{"MYSQL"}{$db_name}.":".$CONFIG->{"MYSQL"}{"host"}.":".$CONFIG->{"MYSQL"}{"port"}
     }
-    my $db = DBI->connect($dbi, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
+    my $db = DBI->connect($dbistring, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
     return $db;
 }
 

--- a/scripts/homer_mysql_rotate.pl
+++ b/scripts/homer_mysql_rotate.pl
@@ -207,10 +207,14 @@ exit;
 sub db_connect {
     my $CONFIG  = shift;
     my $db_name = shift;
-
-    my $db = DBI->connect("DBI:mysql:".$CONFIG->{"MYSQL"}{$db_name}.":".$CONFIG->{"MYSQL"}{"host"}.":".$CONFIG->{"MYSQL"}{"port"}, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
+    my $dbi = ""
+    if($CONFIG->{"MYSQL"}{$usesocket}) {
+    	$dbi = "DBI:mysql:database=".$CONFIG->{"MYSQL"}{$db_name}.";mysql_socket=".$CONFIG->{"MYSQL"}{$socket)
+    } else {
+    	$dbi = "DBI:mysql:".$CONFIG->{"MYSQL"}{$db_name}.":".$CONFIG->{"MYSQL"}{"host"}.":".$CONFIG->{"MYSQL"}{"port"}
+    }
+    my $db = DBI->connect($dbi, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
     return $db;
-
 }
 
 sub calculate_gmt_offset {

--- a/scripts/homer_mysql_rotate.pl
+++ b/scripts/homer_mysql_rotate.pl
@@ -207,13 +207,13 @@ exit;
 sub db_connect {
     my $CONFIG  = shift;
     my $db_name = shift;
-    my $dbi = ""
-    if($CONFIG->{"MYSQL"}{$usesocket}) {
-    	$dbi = "DBI:mysql:database=".$CONFIG->{"MYSQL"}{$db_name}.";mysql_socket=".$CONFIG->{"MYSQL"}{$socket)
+    my $dbistring = ""
+    if($CONFIG->{"MYSQL"}{"usesocket"}) {
+    	$dbi = "DBI:mysql:database=".$CONFIG->{"MYSQL"}{$db_name}.";mysql_socket=".$CONFIG->{"MYSQL"}{"socket"}
     } else {
     	$dbi = "DBI:mysql:".$CONFIG->{"MYSQL"}{$db_name}.":".$CONFIG->{"MYSQL"}{"host"}.":".$CONFIG->{"MYSQL"}{"port"}
     }
-    my $db = DBI->connect($dbi, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
+    my $db = DBI->connect($dbistring, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
     return $db;
 }
 

--- a/scripts/rotation.ini
+++ b/scripts/rotation.ini
@@ -1,10 +1,12 @@
 #Rotation parameters
 
 [MYSQL]
-    user=homer_user
-    password=homer_password
-    host=localhost
-    port=3306
+    user = homer_user
+    password = homer_password
+    host = localhost
+    port = 3306
+    usesocket = 1
+    socket = /var/run/mysqld/mysqld.sock
     db_data = homer_data
     db_stats = homer_statistic
     # Extra param


### PR DESCRIPTION
Hopefully the signing is all working this time.
