### PR TITLE
Initialize $boards variable to squelch PHP notice

### DIFF
--- a/api/RestApi/Dashboard.php
+++ b/api/RestApi/Dashboard.php
@@ -345,6 +345,7 @@ class Dashboard {
         }
                 
         $db->executeQuery($query);
+        $boards = array();
         return $boards;
     }    
     


### PR DESCRIPTION
Just copied same array() initialization as in [postIdDashboard()](https://github.com/sipcapture/homer-api/blob/master/api/RestApi/Dashboard.php#L304)
