### PR TITLE
Properly fix missing argument for sprintf

### DIFF
--- a/scripts/homer_mysql_rotate.pl
+++ b/scripts/homer_mysql_rotate.pl
@@ -150,7 +150,7 @@ foreach my $table (keys %{ $CONFIG->{"DATA_TABLE_ROTATION"} }) {
         my $sth = $db->prepare($query);
         $sth->execute();
         my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = gmtime(time() - 86400*$rotation_horizon);
-        my $oldest = sprintf("%04d%02d%02d%02d",($year+=1900),(++$mon),$mday,$hour);
+        my $oldest = sprintf("%04d%02d%02d",($year+=1900),(++$mon),$mday);
         $oldest+=0;
         while(my @ref = $sth->fetchrow_array()) {
            my $table_name = $ref[0];


### PR DESCRIPTION
I believe the previous patch was wrong. It would lead to newly created tables being dropped because of some comparison returning true. I think the proper solution would be to drop $hour as it is not part of the naming convention used for tables.

Can someone review this more closely? As I said, I am not very familiar with this code.

Resolves Issues: -
See Also: -
