### PR TITLE
Fix missing $layer variable to create an alias.

### DIFF
--- a/api/RestApi/Admin.php
+++ b/api/RestApi/Admin.php
@@ -298,6 +298,8 @@ class Admin {
         $db = $this->getContainer('db');
         $db->select_db(DB_CONFIGURATION);
         $db->dbconnect();
+
+        $layer = $this->getContainer('layer');
                          
         $data = array();
 


### PR DESCRIPTION
To create a new alias, homer is throwing an exception because of a missing $layer.
