### PR TITLE
Destination Stats: associate method to response_code

### DIFF
--- a/api/RestApi/Statistic.php
+++ b/api/RestApi/Statistic.php
@@ -780,9 +780,11 @@ class Statistic {
             $search[$key]['method'] = getVar('method', NULL, $filter, 'string');
             $search[$key]['prefix'] = getVar('prefix', NULL, $filter, 'string');
             $search[$key]['country'] = getVar('country', NULL, $filter, 'string');
+            $search[$key]['status_code'] = getVar('status_code', NULL, $filter, 'string');
             if($search[$key]['country'] == "ALL") $search[$key]['country'] = NULL;
             if($search[$key]['prefix'] == "ALL") $search[$key]['prefix'] = NULL;
             if($search[$key]['method'] == "ALL") $search[$key]['method'] = NULL;
+            if($search[$key]['status_code'] == "ALL") $search[$key]['status_code'] = NULL;
             $callwhere = generateWhere($search[$key], 1, $db, 0);
             if(count($callwhere)) $calldata[] = "(". implode(" AND ", $callwhere). ")";
         }
@@ -823,12 +825,12 @@ class Statistic {
 
 	if($total)
 	{
-		$layerHelper['values'][] = "id, COUNT(id) as cnt,SUM(total) as total, country, prefix, method";
-	        $layerHelper['group']['by'] = "id,from_ts,to_ts,country,prefix,method";
+		$layerHelper['values'][] = "id, COUNT(id) as cnt,SUM(total) as total, country, prefix, method, status_code";
+	        $layerHelper['group']['by'] = "id,from_ts,to_ts,country,prefix,method,status_code";
 	}
 	else
 	{
-		$layerHelper['values'][] = "id, country, prefix, method, total";
+		$layerHelper['values'][] = "id, country, prefix, method, status_code, total";
         }
 
         $query = $layer->querySearchData($layerHelper);

--- a/sql/schema_statistic.sql
+++ b/sql/schema_statistic.sql
@@ -181,14 +181,15 @@ CREATE TABLE IF NOT EXISTS `stats_dest_mem` (
   `create_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `prefix` varchar(50) NOT NULL,
   `method` varchar(50) NOT NULL DEFAULT '',
-  `reply_reason` varchar(100) NOT NULL DEFAULT '',
+  `status_code` varchar(3) NOT NULL DEFAULT '',
+  `reason_phrase` varchar(100) NOT NULL DEFAULT '',
   `country` varchar(255) NOT NULL DEFAULT 'UN',
   `lat` float NOT NULL DEFAULT '0',
   `lon` float NOT NULL DEFAULT '0',
   `duration` int,
   `total` int(20) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `datemethod` (`country` ,`prefix`,`method`)
+  UNIQUE KEY `datemethod` (`country` ,`prefix`, `method`, `status_code`)
 ) ENGINE=MEMORY DEFAULT CHARSET=latin1;
 
 -- --------------------------------------------------------
@@ -203,17 +204,19 @@ CREATE TABLE IF NOT EXISTS `stats_dest_reply` (
   `to_date` timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
   `prefix` varchar(50) NOT NULL,
   `method` varchar(50) NOT NULL DEFAULT '',
-  `reply_reason` varchar(100) NOT NULL DEFAULT '',
+  `status_code` varchar(3) NOT NULL DEFAULT '',
+  `reason_phrase` varchar(100) NOT NULL DEFAULT '',
   `country` varchar(255) NOT NULL DEFAULT 'UN',
   `lat` float NOT NULL DEFAULT '0',
   `lon` float NOT NULL DEFAULT '0',
   `total` int(20) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`from_date`),
-  UNIQUE KEY `datemethod` (`from_date`,`to_date`, `country`, `prefix`,`method`),
+  UNIQUE KEY `datemethod` (`from_date`,`to_date`, `country`, `prefix`, `method`, `status_code`),
   KEY `from_date` (`from_date`),
   KEY `to_date` (`to_date`),
   KEY `prefix` (`prefix`),
-  KEY `method` (`method`)
+  KEY `method` (`method`),
+  KEY `status_code` (`status_code`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
 /*!50100 PARTITION BY RANGE ( UNIX_TIMESTAMP(`from_date`))
 (PARTITION pmax VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */ ;


### PR DESCRIPTION
This is part of 3 PRs involving homer-docker (kamailio.cfg), homer-api (api/RestApi/Statistic.php) and homer-ui (js/widgets/datasource.js).

The objective is to distinguish, in Destination Stats, responses associated to different methods, e.g. a 200 to INVITE from a 200 to BYE.