### PR TITLE
isup: Take src-ip/dest-ip into account when creating unique messages

### DIFF
--- a/api/RestApi/Search.php
+++ b/api/RestApi/Search.php
@@ -2125,10 +2125,11 @@ class Search {
         $hostcount=0;
         /* make them unique and extract host info */
         foreach($data as $key=>$row) {
-            if(isset($message[$row['md5sum']]))
+            $unique_key = $row['md5sum'].'-'.$row['source_ip'].'-'.$row['destination_ip'];
+            if(isset($message[$unique_key]))
                 unset($data[$key]);
             else
-                $message[$row['md5sum']] = $row['node'];
+                $message[$unique_key] = $row['node'];
         }
 
         $localdata = array();


### PR DESCRIPTION
If we capture on STP A and STP B and a message is being forwarded from
A to B and then B to C we want to see the message twice. The current
unique feature would limit it to only A to B. Put the source and the
destination ip into the unique_key.