### PR TITLE
$layer missing from doNewAlarmConfig()

### DIFF
--- a/api/RestApi/Alarm.php
+++ b/api/RestApi/Alarm.php
@@ -118,7 +118,10 @@ class Alarm {
         $db = $this->getContainer('db');
         $db->select_db(DB_STATISTIC);
         $db->dbconnect();
-                         
+
+        /* get our DB Abstract Layer */
+        $layer = $this->getContainer('layer');
+    	    
         $data = array();
 
         $search = array();


### PR DESCRIPTION
New alarm configuration is broken because the $layer variable wasn't created. 