### PR TITLE
Add Upserts to example Postgres kamailio config

### DIFF
--- a/examples/pgsql/kamailio.cfg
+++ b/examples/pgsql/kamailio.cfg
@@ -12,7 +12,7 @@
 #     - define WITH_STATISTIC_INVITE_1XX
 
 
-
+#!substdef "!HOMER_DB_HOST!<homer-db-hostname>!g"
 #!substdef "!HOMER_DB_USER!homer_user!g"
 #!substdef "!HOMER_DB_PASSWORD!homer_password!g"
 #!substdef "!HOMER_LISTEN_PROTO!udp!g"
@@ -29,7 +29,7 @@ memdbg=5
 memlog=5
 
 ##!define KAMAILIO_4_3
-#!define WITH_HOMER_GEO
+##!define WITH_HOMER_GEO
 ##!define WITH_HOMER_CUSTOM_STATS #enable it for HTTP custom stats
 
 log_facility=LOG_LOCAL1
@@ -40,7 +40,7 @@ children=5
 /* uncomment the next line to disable TCP (default on) */
 disable_tcp=yes
 
-/* IP and port for HEP capturing) */
+/* IP and port for HEP capturing */
 listen=HOMER_LISTEN_PROTO:HOMER_LISTEN_IF:HOMER_LISTEN_PORT
 
 #!ifdef WITH_HOMER_CUSTOM_STATS
@@ -73,7 +73,6 @@ loadmodule "jansson.so"
 loadmodule "avpops.so"
 #!endif
 
-
 modparam("htable", "htable", "a=>size=8;autoexpire=400")
 modparam("htable", "htable", "b=>size=8;autoexpire=31")
 # TODO: tune autoexpire setting for htable "c"
@@ -87,12 +86,12 @@ modparam("xhttp", "url_match", "^/api/v1/stat")
 modparam("rtimer", "timer", "name=ta;interval=60;mode=1;")
 modparam("rtimer", "exec", "timer=ta;route=TIMER_STATS")
 
-modparam("sqlops","sqlcon","cb=>postgres://HOMER_DB_USER:HOMER_DB_PASSWORD@127.0.0.1/homer_statistic")
+modparam("sqlops","sqlcon","cb=>postgres://HOMER_DB_USER:HOMER_DB_PASSWORD@HOMER_DB_HOST/homer_statistic")
 
 # ----- mi_fifo params -----
 
 ####### Routing Logic ########
-modparam("sipcapture", "db_url", "postgres://HOMER_DB_USER:HOMER_DB_PASSWORD@127.0.0.1/homer_data")
+modparam("sipcapture", "db_url", "postgres://HOMER_DB_USER:HOMER_DB_PASSWORD@HOMER_DB_HOST/homer_data")
 modparam("sipcapture", "capture_on", 1)
 modparam("sipcapture", "hep_capture_on", 1)
 modparam("sipcapture", "insert_retries", 5)
@@ -135,21 +134,20 @@ route {
 	if (is_method("INVITE|REGISTER")) {
 
 		if($ua =~ "(friendly-scanner|sipvicious|sipcli)") {
-			sql_query("cb", "INSERT INTO alarm_data_mem (create_date, type, total, source_ip, description) VALUES(NOW(), 'scanner', 1, '$si', 'Friendly scanner alarm!')");
+			sql_query("cb", "INSERT INTO alarm_data_mem (create_date, type, total, source_ip, description) VALUES(NOW(), 'scanner', 1, '$si', 'Friendly scanner alarm!') ON CONFLICT (type, source_ip) DO UPDATE SET total=alarm_data_mem.total+1");
 			route(KILL_VICIOUS);
 		}
 
 		#IP Method
-		sql_query("cb", "INSERT INTO stats_ip_mem ( method, source_ip, total) VALUES('$rm', '$si', 1) ");
-		xlog("INSERT INTO stats_ip_mem ( method, source_ip, total) VALUES('$rm', '$si', 1) ;");
+		sql_query("cb", "INSERT INTO stats_ip_mem (method, source_ip, total) VALUES($(rm{sql.val}), '$si', 1) ON CONFLICT (method, source_ip) DO UPDATE SET total=stats_ip_mem.total+1");
+		#xlog("INSERT INTO stats_ip_mem (method, source_ip, total) VALUES($(rm{sql.val}), '$si', 1) ON CONFLICT (method, source_ip) DO UPDATE SET total=stats_ip_mem.total+1;");
 
 #!ifdef WITH_HOMER_GEO
 		if(geoip_match("$si", "src")) {
                         xlog("REGISTER|INVITE SIP message [$si] from: $gip(src=>cc)\n");
-                        sql_query("cb", "INSERT INTO stats_geo_mem ( method, country, lat, lon, total) VALUES('$rm', '$gip(src=>cc)', '$gip(src=>lat)', '$gip(src=>lon)', 1)");
+                        sql_query("cb", "INSERT INTO stats_geo_mem ( method, country, lat, lon, total) VALUES($(rm{sql.val}), '$gip(src=>cc)', '$gip(src=>lat)', '$gip(src=>lon)', 1) ON CONFLICT(method, country) DO UPDATE SET total=stats_geo_mem.total+1");
                 }
 #!endif
-
 
 		if($au != $null)  $var(anumber) = $au;
 		else $var(anumber) = $fU;
@@ -203,7 +201,8 @@ route {
 				}
 
 				if($ua != $null) {
-					sql_query("cb", "INSERT INTO stats_useragent_mem (useragent, method, total) VALUES('$ua', 'INVITE', 1) ");
+					sql_query("cb", "INSERT INTO stats_useragent_mem (useragent, method, total) VALUES($(ua{sql.val}), 'INVITE', 1) ON CONFLICT (useragent, method) DO UPDATE SET total=stats_useragent_mem.total+1");
+
 				}
 
 			}					
@@ -218,7 +217,7 @@ route {
 			}
 			
 			if($ua != $null) {
-				sql_query("cb", "INSERT INTO stats_useragent_mem (useragent, method, total) VALUES('$ua', 'REGISTER', 1)");
+				sql_query("cb", "INSERT INTO stats_useragent_mem (useragent, method, total) VALUES($(ua{sql.val}), 'REGISTER', 1) ON CONFLICT (useragent, method) DO UPDATE SET total=stats_useragent_mem.total+1");
 			}
 		}
 
@@ -435,7 +434,6 @@ onreply_route {
 	route(STORE);
 	drop;
 }
-
 route[KILL_VICIOUS] {
 	xlog("Kill-Vicious ! si : $si ru : $ru ua : $ua\n");
 	return;
@@ -547,7 +545,6 @@ route[CHECK_ALARM]
     sql_query("cb", "DELETE FROM alarm_data WHERE create_date < NOW() - interval '5 day'");
 }
 
-
 route[CHECK_STATS] {
 
     #SQL STATS
@@ -580,35 +577,35 @@ route[CHECK_STATS] {
     #INSERT SQL STATS
     #Packet HEP stats
     if($sht(a=>packet::count) != $null && $sht(a=>packet::count) > 0) {
-        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'packet_count', $sht(a=>packet::count))");
+        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'packet_count', $sht(a=>packet::count)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=stats_data.total+$sht(a=>packet::count)");
         $sht(a=>packet::count) = 0;
     }
     if($sht(a=>packet::size) != $null && $sht(a=>packet::size) > 0) {
-        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'packet_size', $sht(a=>packet::size))");
+        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'packet_size', $sht(a=>packet::size)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=stats_data.total+$sht(a=>packet::size)");
         $sht(a=>packet::size) = 0;
     }
 
     #SDF
     if($sht(a=>stats::sdf) != $null && $sht(a=>stats::sdf) > 0) {
-        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'sdf', $sht(a=>stats::sdf))");
+        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'sdf', $sht(a=>stats::sdf)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=stats_data.total+$sht(a=>stats::sdf)");
         $sht(a=>stats::sdf) = 0;
     }
 
     #ISA
     if($sht(a=>stats::isa) != $null && $sht(a=>stats::isa) > 0) {
-        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'isa', $sht(a=>stats::isa))");
+        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'isa', $sht(a=>stats::isa)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=stats_data.total+$sht(a=>stats::isa)");
         $sht(a=>stats::isa) = 0;
     }
 
     #SD
     if($sht(a=>stats::sd) != $null && $sht(a=>stats::sd) > 0) {
-        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'isa', $sht(a=>stats::sd))");
+        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'isa', $sht(a=>stats::sd)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=stats_data.total+$sht(a=>stats::sd)");
         $sht(a=>stats::sd) = 0;
     }
 
     #SSR
     if($sht(a=>stats::ssr) != $null && $sht(a=>stats::ssr) > 0) {
-        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'ssr', $sht(a=>stats::ssr))");
+        sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'ssr', $sht(a=>stats::ssr)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=stats_data.total+$sht(a=>stats::ssr)");
         $sht(a=>stats::ssr) = 0;
     }
 
@@ -626,7 +623,7 @@ route[CHECK_STATS] {
     }
 
     #Stats DATA
-    sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'asr', $var(asr))");
+    sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'asr', $var(asr)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=(stats_data.total+$var(asr))/2");
 
 
     #NER
@@ -646,79 +643,79 @@ route[CHECK_STATS] {
         }
     }
 
-    sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'ner', $var(ner))");
+    sql_query("cb", "INSERT INTO stats_data (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), 'ner', $var(ner)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=(stats_data.total+$var(ner))/2");
 
     #INVITE
     if($sht(a=>method::reinvite) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, totag, total) VALUES($var(f_date), $var(t_date),'INVITE', 1, $sht(a=>method::reinvite))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, totag, total) VALUES($var(f_date), $var(t_date),'INVITE', 1, $sht(a=>method::reinvite)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::reinvite)");
         $sht(a=>method::reinvite) = 0;
     }
 
     #INVITE
     if($sht(a=>method::invite) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'INVITE', $sht(a=>method::invite))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'INVITE', $sht(a=>method::invite)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::invite)");
         $sht(a=>method::invite) = 0;
     }
 
     #INVITE AUTH
     if($sht(a=>method::invite::auth) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, auth, total) VALUES($var(f_date), $var(t_date), 'INVITE', 1, $sht(a=>method::invite::auth))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, auth, total) VALUES($var(f_date), $var(t_date), 'INVITE', 1, $sht(a=>method::invite::auth)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::invite::auth)");
         $sht(a=>method::invite::auth) = 0;
     }
 
     #REGISTER
     if($sht(a=>method::register) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'REGISTER', $sht(a=>method::register))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'REGISTER', $sht(a=>method::register)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::register)");
         $sht(a=>method::register) = 0;
     }
 
     #REGISTER AUTH
     if($sht(a=>method::register::auth) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, auth, total) VALUES($var(f_date), $var(t_date), 'REGISTER', 1, $sht(a=>method::register::auth))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, auth, total) VALUES($var(f_date), $var(t_date), 'REGISTER', 1, $sht(a=>method::register::auth)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::register::auth)");
         $sht(a=>method::register::auth) = 0;
     }
 
     #BYE
     if($sht(a=>method::bye) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'BYE', $sht(a=>method::bye))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'BYE', $sht(a=>method::bye)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::bye)");
         $sht(a=>method::bye) = 0;
     }
 
     #CANCEL
     if($sht(a=>method::cancel) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'CANCEL', $sht(a=>method::cancel))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'CANCEL', $sht(a=>method::cancel)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::cancel)");
         $sht(a=>method::cancel) = 0;
     }
 
     #OPTIONS
     if($sht(a=>method::options) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'OPTIONS', $sht(a=>method::options))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'OPTIONS', $sht(a=>method::options)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::options)");
         $sht(a=>method::options) = 0;
     }
 
 #!ifdef WITH_STATISTIC_METHOD_EXTRA
     #UNKNOWN
     if($sht(a=>method::unknown) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'UNKNOWN', $sht(a=>method::unknown))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'UNKNOWN', $sht(a=>method::unknown)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::unknown)");
         $sht(a=>method::unknown) = 0;
     }
     
     #ACK
     if($sht(a=>method::ack) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'ACK', $sht(a=>method::ack))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'ACK', $sht(a=>method::ack)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::ack)");
         $sht(a=>method::ack) = 0;
     }
 #!endif
 
     #REFER
     if($sht(a=>method::refer) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'REFER', $sht(a=>method::refer))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'REFER', $sht(a=>method::refer)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::refer)");
         $sht(a=>method::refer) = 0;
     }
 
     #UPDATE
     if($sht(a=>method::update) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'UPDATE', $sht(a=>method::update))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'UPDATE', $sht(a=>method::update)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::update)");
         $sht(a=>method::update) = 0;
     }
 
@@ -726,38 +723,38 @@ route[CHECK_STATS] {
 
     #300
     if($sht(a=>response::300) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), '300', $sht(a=>response::300))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), '300', $sht(a=>response::300)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::300)");
         $sht(a=>response::300) = 0;
     }
 
     #407 INVITE
     if($sht(a=>response::407::invite) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '407', 'INVITE', $sht(a=>response::407::invite))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '407', 'INVITE', $sht(a=>response::407::invite)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::407::invite)");
         $sht(a=>response::407::invite) = 0;
     }
 
     #401 INVITE
     if($sht(a=>response::401::invite) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '401', 'INVITE', $sht(a=>response::401::invite))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '401', 'INVITE', $sht(a=>response::401::invite)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::401::invite)");
         $sht(a=>response::401::invite) = 0;
     }
 
 #!ifdef WITH_STATISTIC_INVITE_1XX
     #100 INVITE
     if($sht(a=>response::100::invite) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '100', 'INVITE', $sht(a=>response::100::invite))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '100', 'INVITE', $sht(a=>response::100::invite)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::100::invite)");
         $sht(a=>response::100::invite) = 0;
     }
 
     #180 INVITE
     if($sht(a=>response::180::invite) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '180', 'INVITE', $sht(a=>response::180::invite))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '180', 'INVITE', $sht(a=>response::180::invite)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::180::invite)");
         $sht(a=>response::180::invite) = 0;
     }
 
     #183 INVITE
     if($sht(a=>response::183::invite) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '183', 'INVITE', $sht(a=>response::183::invite))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '183', 'INVITE', $sht(a=>response::183::invite)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::183::invite)");
         $sht(a=>response::183::invite) = 0; 
     }
 
@@ -765,37 +762,37 @@ route[CHECK_STATS] {
 
     #200 INVITE
     if($sht(a=>response::200::invite) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '200', 'INVITE', $sht(a=>response::200::invite))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '200', 'INVITE', $sht(a=>response::200::invite)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::200::invite)");
         $sht(a=>response::200::invite) = 0;
     }
 
     #407 BYE
     if($sht(a=>response::407::bye) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '407', 'BYE', $sht(a=>response::407::bye))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '407', 'BYE', $sht(a=>response::407::bye)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::407::bye)");
         $sht(a=>response::407::bye) = 0;
     }
 
     #401 BYE
     if($sht(a=>response::401::bye) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '401', 'BYE', $sht(a=>response::401::bye))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '401', 'BYE', $sht(a=>response::401::bye)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::401::bye)");
         $sht(a=>response::401::bye) = 0;
     }
 
     #200 BYE
     if($sht(a=>response::200::bye) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '200', 'BYE', $sht(a=>response::200::bye))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, cseq, total) VALUES($var(f_date), $var(t_date), '200', 'BYE', $sht(a=>response::200::bye)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>response::200::bye)");
         $sht(a=>response::200::bye) = 0;
     }
 
     #ALL TRANSACTIONS MESSAGES
     if($sht(a=>method::all) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'ALL', $sht(a=>method::all))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'ALL', $sht(a=>method::all)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::all)");
         $sht(a=>method::all) = 0;
     }
     
      #ALL MESSAGES ON INTERFACE
     if($sht(a=>method::total) > 0) {
-        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'TOTAL', $sht(a=>method::total))");
+        sql_query("cb", "INSERT INTO stats_method (from_date, to_date, method, total) VALUES($var(f_date), $var(t_date), 'TOTAL', $sht(a=>method::total)) ON CONFLICT (from_date, to_date, method, auth, totag, cseq) DO UPDATE SET total=stats_method.total+$sht(a=>method::total)");
         $sht(a=>method::total) = 0;
     }
 
@@ -804,7 +801,7 @@ route[CHECK_STATS] {
     sht_iterator_start("i1", "d");
     while(sht_iterator_next("i1")) {
                 $var(key) = $(shtitkey(i1){s.select,2,:});
-                sql_query("cb", "INSERT INTO stats_generic (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), '$var(key)', $shtitval(i1))"); 
+                sql_query("cb", "INSERT INTO stats_generic (from_date, to_date, type, total) VALUES($var(f_date), $var(t_date), '$var(key)', $shtitval(i1)) ON CONFLICT (from_date, to_date, type) DO UPDATE SET total=(stats_generic.total+$shtitval(i1))/2"); 
     }
     sht_iterator_end("i1");
     sht_rm_name_re("d=>.*");


### PR DESCRIPTION
Should fix issue #122 and the same method might also be used to fix /sipcapture/homer/issues/294, although it would have to be updated to match the Homer7 DB schema.

I believe that every INSERT that has an "ON DUPLICATE KEY UPDATE" in the
MySQL example config has now been updated with the analogous Postgres
"upsert" syntax.

I used the conflict keys from actual DB insert errors in the kamailio
logs to get me started, then was able to look at the table definitions
and tell which index columns would cause unique constraint conflicts.

This config has been running in our environment for weeks without any
unique constraint errors.